### PR TITLE
Bump Go from 1.21 to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/amp-buildpacks/aptos
 
-go 1.21
+go 1.20
 
 require (
 	github.com/buildpacks/libcnb v1.30.1


### PR DESCRIPTION
Bumps Go from 1.21 to 1.20 and update Go modules used by the project. See the commit for details on what modules were updated.

<details>
<summary>Release Notes</summary>

</details>