### PR TITLE
Bump Go from 1.22 to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/amp-buildpacks/aptos
 
-go 1.22
+go 1.23
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
Bumps Go from 1.22 to 1.23 and update Go modules used by the project. See the commit for details on what modules were updated.

<details>
<summary>Release Notes</summary>

</details>