### PR TITLE
Bump Go from 1.25 to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/amp-buildpacks/aptos
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
Bumps Go from 1.25 to 1.26 and update Go modules used by the project. See the commit for details on what modules were updated.

<details>
<summary>Release Notes</summary>

</details>